### PR TITLE
draft implementation of pcdm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+#Ontology for the Portland Common Data Model
+
+Namespace: http://pcdm.org/models#
+
+This model is intended to underlie a wide array of repository and DAMS applications.
+
+For more information see: https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model

--- a/models.rdf
+++ b/models.rdf
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<rdf:RDF 
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:ore="http://www.openarchives.org/ore/terms/"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+
+    <rdf:Description rdf:about="http://pcdm.org/models#">
+      <dcterms:title xml:lang="en">Portland Common Data Model</dcterms:title>
+      <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-03-16</dcterms:modified>
+      <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
+      <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model"/>
+      <rdfs:comment xml:lang="en">Ontology for the Portland Common Data Model, intended to underlie a wide array of repository and DAMS applications.</rdfs:comment>
+      <owl:versionInfo>2015/03/16</owl:versionInfo>
+    </rdf:Description>
+    
+    <rdfs:Class rdf:about="http://pcdm.org/models#AdministrativeSet">
+      <rdfs:label xml:lang="en">Administrative Set</rdfs:label>
+      <rdfs:comment xml:lang="en">
+        An Administrative Set is a grouping of resources that an administrative unit is ultimately
+        responsible for managing. The set itself helps to manage the items within it. An Object
+        or Collection may be contained by only one AdministrativeSet.
+      </rdfs:comment>
+      <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdfs:Class>
+
+    <rdfs:Class rdf:about="http://pcdm.org/models#Collection">
+      <rdfs:label xml:lang="en">Collection</rdfs:label>
+      <rdfs:comment xml:lang="en">
+        A Collection is a group of resources. Collections have descriptive metadata, access metadata,
+        and may links to works and/or collections. By default, member works and collections are an
+        unordered set, but can be ordered using the ORE Proxy class.
+      </rdfs:comment>
+      <rdfs:subClassOf rdf:resource="http://www.openarchives.org/ore/terms/Aggregation"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdfs:Class>
+
+    <rdfs:Class rdf:about="http://pcdm.org/models#Object">
+      <rdfs:label xml:lang="en">Object</rdfs:label>
+      <rdfs:comment xml:lang="en">
+        An Object is an intellectual entity, sometimes called a "work", "digital object", etc.
+        Objects have descriptive metadata, access metadata, may contain files and other Objects as
+        member "components". Each level of a work is therefore represented by an Object instance,
+        and is capable of standing on its own, being linked to from Collections and other Objects.
+        Member Objects can be ordered using the ORE Proxy class.
+      </rdfs:comment>
+      <rdfs:subClassOf rdf:resource="http://www.openarchives.org/ore/terms/Aggregation"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdfs:Class>
+   
+    <rdfs:Class rdf:about="http://pcdm.org/models#File">
+      <rdfs:label xml:lang="en">File</rdfs:label>
+      <rdfs:comment xml:lang="en">
+        A File is a sequence of binary data and is described by some accompanying metadata.
+        The metadata typically includes at least basic technical metadata (size, content type,
+        modification date, etc.), but can also include properties related to preservation,
+        digitization process, provenance, etc. Files MUST be contained by exactly one Object.
+      </rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdfs:Class>
+
+    <rdf:Property rdf:about="http://pcdm.org/models#hasFile">
+      <rdfs:label xml:lang="en">has file</rdfs:label>
+      <rdfs:comment xml:lang="en">Links to a File contained by this Object.</rdfs:comment>
+      <rdfs:domain rdf:resource="http://pcdm.org/models#Object"/>
+      <rdfs:range rdf:resource="http://pcdm.org/models#File"/>
+      <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/ldp#contains"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdf:Property>
+
+    <rdf:Property rdf:about="http://pcdm.org/models#hasMember">
+      <rdfs:label xml:lang="en">has member</rdfs:label>
+      <rdfs:comment xml:lang="en">Links to a related Object. Typically used to link to component parts, such as a book linking to a page.</rdfs:comment>
+      <rdfs:domain rdf:resource="http://www.openarchives.org/ore/terms/Aggregation"/>
+      <rdfs:range rdf:resource="http://www.openarchives.org/ore/terms/Aggregation"/>
+      <rdfs:subPropertyOf rdf:resource="http://www.openarchives.org/ore/terms/aggregates"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdf:Property>
+
+    <rdf:Property rdf:about="http://pcdm.org/models#hasRelatedFile">
+      <rdfs:label xml:lang="en">has related file</rdfs:label>
+      <rdfs:comment xml:lang="en">Links to a File which is related to this Object but doesn't directly describe or represent it, such as technical metadata about other files.</rdfs:comment>
+      <rdfs:domain rdf:resource="http://pcdm.org/models#Object"/>
+      <rdfs:range rdf:resource="http://pcdm.org/models#File"/>
+      <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/ldp#contains"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdf:Property>
+   
+</rdf:RDF>


### PR DESCRIPTION
This is a draft implementation of the [Portland Common Data Model](https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model)

The date-related properties are set for today, but may need to be changed to reflect an eventual publication date.

I would like some feedback on the `hasMember` property, especially related to the `rdfs:domain` and `rdfs:range`. The documentation indicates that the domain can be either `pcdm:Collection` or `pcdm:Object` (hence the use of the parent class `ore:Aggregation`). The documentation also suggests that, when the subject is a `pcdm:Object`, the range can only by a `pcdm:Object`; however, when the subject is a `pcdm:Collection`, the range can be either a `pcdm:Object` or a `pcdm:Collection`. That constraint is not enforced in this ontology.
