### PR TITLE
update location of wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Namespace: http://pcdm.org/models#
 
 This model is intended to underlie a wide array of repository and DAMS applications.
 
-For more information see: https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model
+For more information see: https://github.com/duraspace/pcdm/wiki

--- a/models.rdf
+++ b/models.rdf
@@ -12,7 +12,7 @@
       <dcterms:title xml:lang="en">Portland Common Data Model</dcterms:title>
       <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-03-16</dcterms:modified>
       <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
-      <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model"/>
+      <rdfs:seeAlso rdf:resource="https://github.com/duraspace/pcdm/wiki"/>
       <rdfs:comment xml:lang="en">Ontology for the Portland Common Data Model, intended to underlie a wide array of repository and DAMS applications.</rdfs:comment>
       <owl:versionInfo>2015/03/16</owl:versionInfo>
     </rdf:Description>

--- a/pcdm-ext/rights.rdf
+++ b/pcdm-ext/rights.rdf
@@ -9,7 +9,7 @@
     <dcterms:title xml:lang="en">Portland Common Data Model: Rights Extension</dcterms:title>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-06-03</dcterms:modified>
     <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
-    <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model"/>
+    <rdfs:seeAlso rdf:resource="https://github.com/duraspace/pcdm/wiki"/>
     <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/hydra/Rights+Metadata+Subgroup"/>
     <rdfs:comment xml:lang="en">Ontology for a PCDM extension to add properties for rights
         overrides.</rdfs:comment>

--- a/pcdm-ext/use.rdf
+++ b/pcdm-ext/use.rdf
@@ -9,7 +9,7 @@
     <dcterms:title xml:lang="en">Portland Common Data Model: Use Extension</dcterms:title>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-05-12</dcterms:modified>
     <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
-    <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/FF/Portland+Common+Data+Model"/>
+    <rdfs:seeAlso rdf:resource="https://github.com/duraspace/pcdm/wiki"/>
     <rdfs:seeAlso rdf:resource="https://wiki.duraspace.org/display/hydra/File+Use+Vocabulary"/>
     <rdfs:comment xml:lang="en">Ontology for a PCDM extension to add subclasses of PCDM File for the
         different roles files have in relation to the Object they are attached to.</rdfs:comment>


### PR DESCRIPTION
The PCDM wiki location has changed. That should be reflected in the README and the associated ontologies.
