### PR TITLE
Adding optional buffer FileSet class and related predicates

### DIFF
--- a/models.rdf
+++ b/models.rdf
@@ -16,8 +16,8 @@
       <dcterms:publisher rdf:resource="http://www.duraspace.org/"/>
       <rdfs:seeAlso rdf:resource="https://github.com/duraspace/pcdm/wiki"/>
       <rdfs:comment xml:lang="en">Ontology for the Portland Common Data Model, intended to underlie a wide array of repository and DAMS applications.</rdfs:comment>
-      <owl:versionInfo>2016/04/18</owl:versionInfo>
-      <owl:priorVersion rdf:resource="http://pcdm.org/2015/09/28/models"/>
+      <owl:versionInfo>2016/09/01</owl:versionInfo>
+      <owl:priorVersion rdf:resource="http://pcdm.org/2016/04/18/models"/>
     </rdf:Description>
     
     <rdfs:Class rdf:about="http://pcdm.org/models#Collection">
@@ -66,6 +66,15 @@
       <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
     </rdfs:Class>
 
+    <rdfs:Class rdf:about="http://pcdm.org/models#FileSet">
+      <rdfs:label xml:lang="en">FileSet</rdfs:label>
+      <rdfs:comment xml:lang="en">
+        A group of related Files, typically a single master File and any derivatives.
+      </rdfs:comment>
+      <rdfs:subClassOf rdf:resource="http://pcdm.org/models#Object"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdfs:Class>
+
     <rdf:Property rdf:about="http://pcdm.org/models#hasFile">
       <rdfs:label xml:lang="en">has file</rdfs:label>
       <rdfs:comment xml:lang="en">Links to a File contained by this Object.</rdfs:comment>
@@ -83,6 +92,25 @@
       <rdfs:subPropertyOf rdf:resource="http://www.openarchives.org/ore/terms/isAggregatedBy"/>
       <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
       <owl:inverseOf rdf:resource="http://pcdm.org/models#hasFile"/>
+    </rdf:Property>
+
+    <rdf:Property rdf:about="http://pcdm.org/models#hasFileSet">
+      <rdfs:label xml:lang="en">has file set</rdfs:label>
+      <rdfs:comment xml:lang="en">Links to a FileSet that represents this Object.</rdfs:comment>
+      <rdfs:domain rdf:resource="http://pcdm.org/models#Object"/>
+      <rdfs:range rdf:resource="http://pcdm.org/models#FileSet"/>
+      <rdfs:subPropertyOf rdf:resource="http://www.openarchives.org/ore/terms/aggregates"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+    </rdf:Property>
+
+    <rdf:Property rdf:about="http://pcdm.org/models#fileSetOf">
+      <rdfs:label xml:lang="en">is file set of</rdfs:label>
+      <rdfs:comment xml:lang="en">Links from a Fileset to its containing Object.</rdfs:comment>
+      <rdfs:range rdf:resource="http://pcdm.org/models#Object"/>
+      <rdfs:domain rdf:resource="http://pcdm.org/models#FileSet"/>
+      <rdfs:subPropertyOf rdf:resource="http://www.openarchives.org/ore/terms/isAggregatedBy"/>
+      <rdfs:isDefinedBy rdf:resource="http://pcdm.org/models#"/>
+      <owl:inverseOf rdf:resource="http://pcdm.org/models#hasFileSet"/>
     </rdf:Property>
 
     <rdf:Property rdf:about="http://pcdm.org/models#hasMember">


### PR DESCRIPTION
Objects can either link directly to Files, or link to FileSets that link to Files:
- Current PCDM:
  
  ```
  <object1> a pcdm:Object ;
  pcdm:hasFile <file1> .
  
  <file1> a pcdm:File .
  ```
- Optional FileSet as a buffer between Object and File:
  
  ```
  <object1> a pcdm:Object ;
  pcdm:hasFileSet <fileset1> .
  
  <fileset1> a pcdm:FileSet ;
  pcdm:hasFile <file1> .
  
  <file1> a pcdm:File .
  ```

See also #69 
