### PR TITLE
Relocate #pcdm from Freenode IRC to Code4lib Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Description: This model is intended to underlie a wide array of repository and D
 ### Communication
 * Project information see: https://github.com/duraspace/pcdm/wiki
 * Email discussion see: https://groups.google.com/d/forum/pcdm
-* IRC discussion see: #pcdm on irc.freenode.net
+* Slack discussion see: #pcdm on the [Code4lib Slack team](https://code4lib.org/irc#slack)
 
 ### Developer resources
 To generate HTML versions of the ontologies:


### PR DESCRIPTION
The Freenode IRC network has recently transitioned into hostile ownership
leading to most of its staffers resigning [0], [1].  The PCDM readme refers
to the #pcdm channel on Freenode, which is infrequently used. As proposed,
there is a newly created #pcdm channel on the Code4lib Slack channel.

[0]: https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409#disclaimer
[1]: https://www.kline.sh/