### PR TITLE
Correct dereferenceable URI for ExtractedText.

### DIFF
--- a/pcdm-ext/use.rdf
+++ b/pcdm-ext/use.rdf
@@ -83,7 +83,7 @@
     <rdfs:comment xml:lang="en">A textual representation of the Object appropriate for presenting to users,
         such as subtitles or transcript of a video.  Can be used as a substitute or complement to other
         files for accessibility purposes.</rdfs:comment>
-    <rdf:subClassOf rdf:resource="http://pcdm.org/models#ExtractedText"/>
+    <rdf:subClassOf rdf:resource="http://pcdm.org/use#ExtractedText"/>
     <rdfs:isDefinedBy rdf:resource="http://pcdm.org/use#"/>
   </rdfs:Class>
 


### PR DESCRIPTION
# What Does This Do

Addresses [Issue 77](https://github.com/duraspace/pcdm/issues/77) by changing the object of the triple for `<http://pcdm.org/use#Transcript> <http://www.w3.org/1999/02/22-rdf-syntax-ns#subClass>` from `<http://pcdm.org/models#ExtractedText>` to the dereferenceable `<http://pcdm.org/use#ExtractedText>`.